### PR TITLE
Adding an option for C# namespace

### DIFF
--- a/src/main/protobuf/ucfg.proto
+++ b/src/main/protobuf/ucfg.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+option csharp_namespace = "SonarAnalyzer.Protobuf.Ucfg";
 option java_package = "org.sonar.ucfg.protobuf";
 option optimize_for = SPEED;
 


### PR DESCRIPTION
Protobuf classes should be generated in a namespace, otherwise they collide with built-in classes, such as `Location` (from Roslyn)