### PR TITLE
Use Jenkinsfile library v2 to free some node usage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,7 @@
-@Library('SonarSource@1.6') _
+@Library('SonarSource@2.0') _
 
 pipeline {
-  agent {
-    label 'linux'
-  }
+  agent none
   parameters {
     string(name: 'GIT_SHA1', description: 'Git SHA1 (provided by travisci hook job)')
     string(name: 'CI_BUILD_NAME', defaultValue: 'sonar-ucfg', description: 'Build Name (provided by travisci hook job)')	


### PR DESCRIPTION
This Jenkinsfile only send notifications to BURGR and promote the artifacts.
With the library version 2, such actions does not require a node anymore.
Then the build can run without waiting time to have a slave available.